### PR TITLE
Fixed #18 (Allow customisation of the bundle command)

### DIFF
--- a/snaplet-purescript.cabal
+++ b/snaplet-purescript.cabal
@@ -1,5 +1,5 @@
 name:                snaplet-purescript
-version:             0.5.2.0
+version:             0.5.2.1
 synopsis:            Automatic (re)compilation of purescript projects
 description:         Automatic (re)compilation of purescript projects
 license:             MIT

--- a/src/Snap/Snaplet/PureScript/Internal.hs
+++ b/src/Snap/Snaplet/PureScript/Internal.hs
@@ -77,6 +77,10 @@ data PureScript = PureScript {
   -- ^ Whether or not bundle everything in a fat app with a PS namespace.
   , pursBundleName :: !T.Text
   -- ^ The name for your bundled output.
+  , pursBundleExe :: !T.Text
+  -- ^ The name for the program used to bundle your app. (e.g. "pulp", "psc-bundle", etc)
+  , pursBundleOpts :: ![T.Text]
+  -- ^ Override the arguments passed to the bundle executable.
   , pursPulpPath :: !PulpPath
   -- ^ The absolute path to a `pulp` executable. This can be user-provided
   -- or inferred automatically by this snaplet.


### PR DESCRIPTION
Hey @tungd ,

I finally had the time of fixing this for good. The configuration file ship now with 2 extra (optional) fields called `bundleExe` and `bundleOpts`. The former allows you to override the executable which performs the bundling (for example, set it to be "pulp") and the latter to completely override & customise the options passed to the executable.

Notable exception is the `--modules` option, which is automatically computed and forwarded by this snaplet to `psc-bundle` or `pulp`, all the rest is customisable.

I hope that this fits your needs!