### PR TITLE
Fix modules option for psc-bundle (duh)

### DIFF
--- a/snaplet-purescript.cabal
+++ b/snaplet-purescript.cabal
@@ -1,5 +1,5 @@
 name:                snaplet-purescript
-version:             0.5.2.1
+version:             0.5.2.2
 synopsis:            Automatic (re)compilation of purescript projects
 description:         Automatic (re)compilation of purescript projects
 license:             MIT

--- a/src/Snap/Snaplet/PureScript.hs
+++ b/src/Snap/Snaplet/PureScript.hs
@@ -156,12 +156,15 @@ bundle PureScript{..} =
         True -> do
           preBundleHook pursHooks
           rm_rf (fromText bundlePath)
-          let modules = T.intercalate "," pursModules
           echo $ "Bundling everything in " <> bundlePath
           res <- case (pursBundleExe, pursBundleOpts) of
-                ("psc-bundle", []) -> run "psc-bundle" (["js/**/*.js", "-m"] <> (T.words modules) <> ["-o", bundlePath, "-n", "PS"])
-                ("pulp", [])       -> run "pulp" (["build", "-I", "src", "--modules"] <> (T.words modules) <> ["-t", bundlePath])
-                (exe, args)        -> run (fromText exe) (args <> ["--modules"] <> (T.words modules))
+                ("psc-bundle", []) ->
+                  let modules = T.intercalate " -m " pursModules
+                  in run "psc-bundle" (["js/**/*.js", "-m"] <> (T.words modules) <> ["-o", bundlePath, "-n", "PS"])
+                ("pulp", [])       ->
+                 let modules = T.intercalate "," pursModules
+                 in run "pulp" (["build", "-I", "src", "--modules"] <> (T.words modules) <> ["-t", bundlePath])
+                (exe, args)        -> run (fromText exe) args
           postBundleHook pursHooks
           eC <- lastExitCode
           case (eC == 0) of


### PR DESCRIPTION
Whilst working on #18 I've realised I have broken the default usage (via `psc-bundle`) as the module option is passed with comma separated modules instead that with `-m`, as `psc-bundle` mandates.

Fixing this!